### PR TITLE
Allow regex in SOURCE_BUCKETS for environment variable

### DIFF
--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -70,7 +70,7 @@ class ImageRequest {
             if (decoded.bucket !== undefined) {
                 // Check the provided bucket against the whitelist
                 const sourceBuckets = this.getAllowedSourceBuckets();
-                if (sourceBuckets.includes(decoded.bucket)) {
+                if (sourceBuckets.includes(decoded.bucket) || decoded.bucket.match(new RegExp('^' + sourceBuckets[0] + '$'))) {
                     return decoded.bucket;
                 } else {
                     throw ({


### PR DESCRIPTION
This allow us to support regex in SOURCE_BUCKETS for the environment variable so that it matches a regex of bucket instead of CSV buckets.

CSV has a limited string limit and doesn't allow user to enter a long list of buckets.